### PR TITLE
Add Existing Tag option

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ When using the `update-build` command, you can generate the header file as descr
 
 ### Build Number Generation
 
-There are two ways that the build number can be generated.
+There are two primary ways that the build number can be generated, with an additional optional override.
 
 The default method uses a count of the commits (produced with `git rev-list --count HEAD`), and thus trends upwards as commits increase.
 
@@ -96,6 +96,10 @@ This tag is presumed to represent the highest in-use build number, and so the ne
 
 These tags are automatically created and pushed to git if the `upload` command succeeds, and so each subsequent upload will be tagged with
 a new higher build number, even if it happens on a different build machine.
+
+Optional override:
+
+- `--adopt-other-platform-build` (or `"adoptOtherPlatformBuild": true` in `.rt.json`) — if the current commit (HEAD) already has a version tag for a different platform in the form `vX.Y.Z-build-OtherPlatform`, the build number from that tag is reused for the current platform. This is useful when cutting simultaneous releases across platforms and you want them to share the same build number. If no such tag is present at HEAD, the normal build-number strategy (incrementing tags or commit count) is used.
 
 
 ## The Full Toolchain

--- a/README.md
+++ b/README.md
@@ -82,22 +82,26 @@ When using the `update-build` command, you can generate the header file as descr
 
 ### Build Number Generation
 
-ReleaseTools supports several strategies for generating the build number, which can be controlled via command-line flags or the `.rt.json` settings file. The options are mutually exclusive where noted, and their precedence is as follows:
+ReleaseTools supports several strategies for generating the build number, which can be controlled via command-line flags or the `.rt.json` settings file:
 
 1. **Explicit Build Number**
    - Use `--explicit-build <number>` to specify the exact build number to use. This takes precedence over all other options. Cannot be combined with `--existing-tag`, `--increment-tag`, or `--offset`.
+   - Generally this is useful if you want to completely reset the build number sequence.
    - Example: `rt archive --explicit-build 1234`
 
-2. **Adopt Build Number from Existing Tag (Cross-Platform Awareness)**
-   - Use `--existing-tag` (or set `"useExistingTag": true` in `.rt.json`) to scan all version tags for all platforms. The tool finds the highest build number for any platform and for the platform being built. If another platform has a higher build number, it uses that. If the highest for any platform matches the current platform, it increments it. Otherwise, it uses the current platform's highest build number. This is useful when cutting simultaneous releases across platforms and you want them to share the same build number or keep them in sync.
-   - Example: `rt submit --platform macOS --existing-tag`
-
-3. **Increment Highest Existing Tag**
+2. **Increment Highest Existing Tag**
    - Use `--increment-tag` (or set `"incrementTag": true` in `.rt.json`) to find the highest build number for the current platform in tags of the form `vX.Y.Z-build-platform`, and increment it by one. If no tags are found, falls back to commit count.
    - Example: `rt archive --increment-tag`
 
+3. **Adopt Build Number from Existing Tag**
+   - Use `--existing-tag` (or set `"useExistingTag": true` in `.rt.json`) to scan all version tags for all platforms. The tool finds the highest build number for any platform and for the platform being built. If another platform has a higher build number, it uses that. If the highest for any platform matches the current platform, it increments it. 
+   - This is useful when cutting simultaneous releases across platforms and you want them to share the same build number or keep them in sync. Typically you will use `--increment-tag` when building the first platform, then `--existing-tag` for the subsequent platforms. This should ensure that they all share the same number.
+   - Example: `rt submit --platform macOS --existing-tag`
+
+
 4. **Commit Count (Default)**
    - If none of the above options are specified, the build number is set to the number of commits in the repository (`git rev-list --count HEAD`).
+   - If you are generally not releasing from multiple branches, this method is often sufficient. However, the commit count is based on the current branch, and so it is possible for it to end up going down if you switch to a branch with fewer commits, and generally being inconsistent between branches. For most situations, using tags is probably more reliable.
 
 #### Option Precedence and Conflicts
 - `--explicit-build` cannot be used with `--existing-tag`, `--increment-tag`, or `--offset`. If conflicting options are provided, the tool will report an error.

--- a/README.md
+++ b/README.md
@@ -101,6 +101,14 @@ Optional override:
 
 - `--adopt-other-platform-build` (or `"adoptOtherPlatformBuild": true` in `.rt.json`) — if the current commit (HEAD) already has a version tag for a different platform in the form `vX.Y.Z-build-OtherPlatform`, the build number from that tag is reused for the current platform. This is useful when cutting simultaneous releases across platforms and you want them to share the same build number. If no such tag is present at HEAD, the normal build-number strategy (incrementing tags or commit count) is used.
 
+Examples:
+
+- Submit with adoption and increment-tag enabled:
+    `rt submit --platform macOS --adopt-other-platform-build --increment-tag`
+
+- Update xcconfig with adoption (repo path explicit):
+    `rt update-build --config Configs/BuildNumber.xcconfig --repo . --adopt-other-platform-build`
+
 
 ## The Full Toolchain
 

--- a/README.md
+++ b/README.md
@@ -99,15 +99,15 @@ a new higher build number, even if it happens on a different build machine.
 
 Optional override:
 
-- `--adopt-other-platform-build` (or `"adoptOtherPlatformBuild": true` in `.rt.json`) — if the current commit (HEAD) already has a version tag for a different platform in the form `vX.Y.Z-build-OtherPlatform`, the build number from that tag is reused for the current platform. This is useful when cutting simultaneous releases across platforms and you want them to share the same build number. If no such tag is present at HEAD, the normal build-number strategy (incrementing tags or commit count) is used.
+- `--existing-tag` (or `"useExistingTag": true` in `.rt.json`) — if the current commit (HEAD) already has a version tag for a different platform in the form `vX.Y.Z-build-OtherPlatform`, the build number from that tag is reused for the current platform. This is useful when cutting simultaneous releases across platforms and you want them to share the same build number. If no such tag is present at HEAD, the normal build-number strategy (incrementing tags or commit count) is used.
 
 Examples:
 
 - Submit with adoption and increment-tag enabled:
-    `rt submit --platform macOS --adopt-other-platform-build --increment-tag`
+    `rt submit --platform macOS --existing-tag --increment-tag`
 
 - Update xcconfig with adoption (repo path explicit):
-    `rt update-build --config Configs/BuildNumber.xcconfig --repo . --adopt-other-platform-build`
+    `rt update-build --config Configs/BuildNumber.xcconfig --repo . --existing-tag`
 
 
 ## The Full Toolchain

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ When using the `update-build` command, you can generate the header file as descr
 ReleaseTools supports several strategies for generating the build number, which can be controlled via command-line flags or the `.rt.json` settings file. The options are mutually exclusive where noted, and their precedence is as follows:
 
 1. **Explicit Build Number**
-   - Use `--explicit-build <number>` (or set `"explicitBuild": "<number>"` in `.rt.json`) to specify the exact build number to use. This takes precedence over all other options. Cannot be combined with `--existing-tag`, `--increment-tag`, or `--offset`.
+   - Use `--explicit-build <number>` to specify the exact build number to use. This takes precedence over all other options. Cannot be combined with `--existing-tag`, `--increment-tag`, or `--offset`.
    - Example: `rt archive --explicit-build 1234`
 
 2. **Adopt Build Number from Existing Tag (Cross-Platform Awareness)**

--- a/README.md
+++ b/README.md
@@ -88,8 +88,8 @@ ReleaseTools supports several strategies for generating the build number, which 
    - Use `--explicit-build <number>` (or set `"explicitBuild": "<number>"` in `.rt.json`) to specify the exact build number to use. This takes precedence over all other options. Cannot be combined with `--existing-tag`, `--increment-tag`, or `--offset`.
    - Example: `rt archive --explicit-build 1234`
 
-2. **Adopt Build Number from Existing Tag at HEAD**
-   - Use `--existing-tag` (or set `"useExistingTag": true` in `.rt.json`) to reuse the build number from a version tag for a different platform at the current commit (HEAD). If no such tag is present, falls back to the next strategy.
+2. **Adopt Build Number from Existing Tag (Cross-Platform Awareness)**
+   - Use `--existing-tag` (or set `"useExistingTag": true` in `.rt.json`) to scan all version tags for all platforms. The tool finds the highest build number for any platform and for the platform being built. If another platform has a higher build number, it uses that. If the highest for any platform matches the current platform, it increments it. Otherwise, it uses the current platform's highest build number. This is useful when cutting simultaneous releases across platforms and you want them to share the same build number or keep them in sync.
    - Example: `rt submit --platform macOS --existing-tag`
 
 3. **Increment Highest Existing Tag**

--- a/Sources/ReleaseTools/Commands/BootstrapCommand.swift
+++ b/Sources/ReleaseTools/Commands/BootstrapCommand.swift
@@ -14,7 +14,7 @@ struct BootstrapCommand: AsyncParsableCommand {
 
     public var description: String {
       switch self {
-      case let .couldntCopyConfigs(error): return "Couldn't copy files \(error)."
+        case .couldntCopyConfigs(let error): return "Couldn't copy files \(error)."
       }
     }
   }

--- a/Sources/ReleaseTools/Commands/UpdateBuildCommand.swift
+++ b/Sources/ReleaseTools/Commands/UpdateBuildCommand.swift
@@ -16,6 +16,8 @@ enum UpdateBuildError: Runner.Error {
   case gettingCommitFailed
   case writingConfigFailed
   case updatingIndexFailed
+  case invalidExplicitBuild(String)
+  case inconsistentTagState(currentPlatform: String)
 
   func description(for session: Runner.Session) async -> String {
     async let stderr = session.stderr.string
@@ -25,6 +27,10 @@ enum UpdateBuildError: Runner.Error {
       case .gettingCommitFailed: return "Failed to get the commit from git.\n\n\(await stderr)"
       case .writingConfigFailed: return "Failed to write the config file.\n\n\(await stderr)"
       case .updatingIndexFailed: return "Failed to tell git to ignore the config file.\n\n\(await stderr)"
+      case .invalidExplicitBuild(let value):
+        return "Invalid explicit build number: \(value). Must be a positive integer."
+      case .inconsistentTagState(let currentPlatform):
+        return "Inconsistent tag state: highest build for platform (\(currentPlatform)) is greater than highest build for any platform. This should not happen. Please check your tags."
     }
   }
 }

--- a/Sources/ReleaseTools/OptionParser+BuildNumber.swift
+++ b/Sources/ReleaseTools/OptionParser+BuildNumber.swift
@@ -11,7 +11,6 @@ extension OptionParser {
   /// Return the build number to use for the next build, and the commit tag it was build from.
   func nextBuildNumberAndCommit(in url: URL, using git: GitRunner) async throws -> (String, String) {
     git.cwd = url
-    // Avoid changing global process CWD; rely on Runner.cwd
 
     // get next build number
     let build: UInt
@@ -23,7 +22,7 @@ extension OptionParser {
       build = explicitBuildNumber
       verbose("Using explicit build number: \(build)")
     } else {
-  // optionally use the build number from an existing tag for another platform
+      // optionally use the build number from an existing tag for another platform
       var adoptedBuild: UInt? = nil
       if useExistingTag {
         adoptedBuild = try await getBuildFromExistingTag(using: git, currentPlatform: platform)

--- a/Sources/ReleaseTools/OptionParser+BuildNumber.swift
+++ b/Sources/ReleaseTools/OptionParser+BuildNumber.swift
@@ -3,7 +3,6 @@
 //  All code (c) 2025 - present day, Elegant Chaos Limited.
 // -=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
 
-import ArgumentParser
 import Foundation
 
 extension OptionParser {
@@ -17,7 +16,7 @@ extension OptionParser {
     if let explicitBuild {
       // use explicitly specified build number
       guard let explicitBuildNumber = UInt(explicitBuild) else {
-        throw ValidationError("Invalid explicit build number: \(explicitBuild). Must be a positive integer.")
+        throw UpdateBuildError.invalidExplicitBuild(explicitBuild)
       }
       build = explicitBuildNumber
       verbose("Using explicit build number: \(build)")
@@ -66,7 +65,7 @@ extension OptionParser {
     } else if maxAny == maxCurrent && maxAny > 0 {
       return maxAny + 1
     } else if maxAny < maxCurrent {
-      throw ValidationError("Inconsistent tag state: highest build for platform (\(currentPlatform)) is greater than highest build for any platform. This should not happen. Please check your tags.")
+      throw UpdateBuildError.inconsistentTagState(currentPlatform: currentPlatform)
     } else if maxCurrent > 0 {
       return maxCurrent
     } else {

--- a/Sources/ReleaseTools/OptionParser+BuildNumber.swift
+++ b/Sources/ReleaseTools/OptionParser+BuildNumber.swift
@@ -17,7 +17,7 @@ extension OptionParser {
     if useExistingTag {
       adoptedBuild = try await getBuildFromExistingTag(using: git, currentPlatform: platform)
       if let adoptedBuild {
-        log("Adopting build number from another platform tag at HEAD: \(adoptedBuild)")
+        verbose("Adopting build number from another platform tag at HEAD: \(adoptedBuild)")
       }
     }
 
@@ -28,7 +28,7 @@ extension OptionParser {
     } else if incrementBuildTag {
       build = try await getBuildByIncrementingTag(using: git, platform: platform)
     } else {
-      build = try await getBuildByCommits(using: git, offset: buildOffset)
+      build = try await getBuildByCommitCount(using: git, offset: buildOffset)
     }
 
     // get current commit
@@ -66,7 +66,7 @@ extension OptionParser {
 
   /// Return the build number to use for the next build.
   /// We calculate the build number by counting the commits in the repo.
-  private func getBuildByCommits(using git: GitRunner, offset: UInt) async throws -> UInt {
+  private func getBuildByCommitCount(using git: GitRunner, offset: UInt) async throws -> UInt {
     let result = git.run(["rev-list", "--count", "HEAD"])
     try await result.throwIfFailed(UpdateBuildError.gettingBuildFailed)
 

--- a/Sources/ReleaseTools/OptionParser+BuildNumber.swift
+++ b/Sources/ReleaseTools/OptionParser+BuildNumber.swift
@@ -12,7 +12,7 @@ extension OptionParser {
     git.cwd = url
     // Avoid changing global process CWD; rely on Runner.cwd
 
-  // optionally use the build number from an existing tag at HEAD (from another platform)
+    // optionally use the build number from an existing tag at HEAD (from another platform)
     var adoptedBuild: UInt? = nil
     if useExistingTag {
       adoptedBuild = try await getBuildFromExistingTag(using: git, currentPlatform: platform)

--- a/Sources/ReleaseTools/OptionParser+BuildNumber.swift
+++ b/Sources/ReleaseTools/OptionParser+BuildNumber.swift
@@ -12,10 +12,10 @@ extension OptionParser {
     git.cwd = url
     // Avoid changing global process CWD; rely on Runner.cwd
 
-    // optionally adopt build number from a different platform tag at HEAD
+  // optionally use the build number from an existing tag at HEAD (from another platform)
     var adoptedBuild: UInt? = nil
-    if adoptOtherPlatformBuild {
-      adoptedBuild = try await getBuildFromOtherPlatformTagAtHEAD(using: git, currentPlatform: platform)
+    if useExistingTag {
+      adoptedBuild = try await getBuildFromExistingTag(using: git, currentPlatform: platform)
       if let adoptedBuild {
         log("Adopting build number from another platform tag at HEAD: \(adoptedBuild)")
       }
@@ -39,8 +39,8 @@ extension OptionParser {
     return (String(build), commit)
   }
 
-  /// Try to find a version tag on the current commit for any platform other than the current one, and return its build number if found.
-  private func getBuildFromOtherPlatformTagAtHEAD(using git: GitRunner, currentPlatform: String) async throws -> UInt? {
+  /// Try to find an existing version tag at HEAD for any platform other than the current one, and return its build number if found.
+  private func getBuildFromExistingTag(using git: GitRunner, currentPlatform: String) async throws -> UInt? {
     // ensure tags are up-to-date
     let fetchResult = git.run(["fetch", "--tags"])
     try await fetchResult.throwIfFailed(UpdateBuildError.fetchingTagsFailed)

--- a/Sources/ReleaseTools/OptionParser.swift
+++ b/Sources/ReleaseTools/OptionParser.swift
@@ -165,6 +165,11 @@ class OptionParser {
       useExistingTag = true
     }
 
+    // useExistingTag implies incrementBuildTag (for fallback behavior)
+    if useExistingTag {
+      incrementBuildTag = true
+    }
+
     // if we've specified the scheme, we also need the workspace
     if requirements.contains(.workspace) || scheme != nil {
       if let workspace = options.workspace ?? defaultWorkspace {
@@ -245,6 +250,12 @@ class OptionParser {
     self.buildOffset = buildOffset
     self.incrementBuildTag = incrementBuildTag
     self.useExistingTag = adoptOtherPlatformBuild
+
+    // useExistingTag implies incrementBuildTag (for fallback behavior)
+    if self.useExistingTag {
+      self.incrementBuildTag = true
+    }
+
     archive = nil
   }
 

--- a/Sources/ReleaseTools/OptionParser.swift
+++ b/Sources/ReleaseTools/OptionParser.swift
@@ -183,25 +183,25 @@ class OptionParser {
     // validate that explicitBuild is not used with conflicting options
     if explicitBuild != nil {
       var conflictingOptions: [String] = []
-      
+
       if let buildOptions, buildOptions.useExistingTag {
         conflictingOptions.append("--existing-tag")
       } else if getSettings().useExistingTag == true {
         conflictingOptions.append("useExistingTag setting")
       }
-      
+
       if let buildOptions, buildOptions.incrementTag {
         conflictingOptions.append("--increment-tag")
       } else if getSettings().incrementTag == true {
         conflictingOptions.append("incrementTag setting")
       }
-      
+
       if let buildOptions, buildOptions.offset != nil {
         conflictingOptions.append("--offset")
       } else if getSettings().offset != nil {
         conflictingOptions.append("offset setting")
       }
-      
+
       if !conflictingOptions.isEmpty {
         throw ValidationError("--explicit-build cannot be used with: \(conflictingOptions.joined(separator: ", "))")
       }

--- a/Sources/ReleaseTools/OptionParser.swift
+++ b/Sources/ReleaseTools/OptionParser.swift
@@ -71,7 +71,7 @@ class OptionParser {
   var workspace: String = ""
   var buildOffset: UInt = 0
   var incrementBuildTag: Bool = true
-  var adoptOtherPlatformBuild: Bool = false
+  var useExistingTag: Bool = false
   var archive: XcodeArchive!
 
   let rootURL = URL(fileURLWithPath: FileManager.default.currentDirectoryPath)
@@ -150,9 +150,9 @@ class OptionParser {
       incrementBuildTag = setting
     }
 
-    // remember the adoptOtherPlatformBuild setting if supplied in settings
-    if let adopt = getSettings().adoptOtherPlatformBuild {
-      adoptOtherPlatformBuild = adopt
+  // remember the useExistingTag setting if supplied in settings
+    if let useExisting = getSettings().useExistingTag {
+      useExistingTag = useExisting
     }
 
     if let buildOptions, buildOptions.incrementTag {
@@ -160,9 +160,9 @@ class OptionParser {
       incrementBuildTag = true
     }
 
-    if let buildOptions, buildOptions.adoptOtherPlatformBuild {
+    if let buildOptions, buildOptions.useExistingTag {
       // ... enabling on the command line takes precedence
-      adoptOtherPlatformBuild = true
+      useExistingTag = true
     }
 
     // if we've specified the scheme, we also need the workspace
@@ -225,7 +225,7 @@ class OptionParser {
   }
 
   /// Lightweight initializer intended for tests where we only need build-number logic.
-  /// It avoids ArgumentParser plumbling and workspace inference.
+  /// It avoids ArgumentParser plumbing and workspace inference.
   init(testingPlatform: String, incrementBuildTag: Bool, adoptOtherPlatformBuild: Bool, buildOffset: UInt = 0) {
     showOutput = false
     showCommands = false
@@ -244,7 +244,7 @@ class OptionParser {
     workspace = ""
     self.buildOffset = buildOffset
     self.incrementBuildTag = incrementBuildTag
-    self.adoptOtherPlatformBuild = adoptOtherPlatformBuild
+  self.useExistingTag = adoptOtherPlatformBuild
     archive = nil
   }
 

--- a/Sources/ReleaseTools/OptionParser.swift
+++ b/Sources/ReleaseTools/OptionParser.swift
@@ -71,6 +71,7 @@ class OptionParser {
   var workspace: String = ""
   var buildOffset: UInt = 0
   var incrementBuildTag: Bool = true
+  var adoptOtherPlatformBuild: Bool = false
   var archive: XcodeArchive!
 
   let rootURL = URL(fileURLWithPath: FileManager.default.currentDirectoryPath)
@@ -149,9 +150,19 @@ class OptionParser {
       incrementBuildTag = setting
     }
 
+    // remember the adoptOtherPlatformBuild setting if supplied in settings
+    if let adopt = getSettings().adoptOtherPlatformBuild {
+      adoptOtherPlatformBuild = adopt
+    }
+
     if let buildOptions, buildOptions.incrementTag {
       // ... a true value on the command line takes precedence
       incrementBuildTag = true
+    }
+
+    if let buildOptions, buildOptions.adoptOtherPlatformBuild {
+      // ... enabling on the command line takes precedence
+      adoptOtherPlatformBuild = true
     }
 
     // if we've specified the scheme, we also need the workspace
@@ -211,6 +222,30 @@ class OptionParser {
       }
     }
 
+  }
+
+  /// Lightweight initializer intended for tests where we only need build-number logic.
+  /// It avoids ArgumentParser plumbling and workspace inference.
+  init(testingPlatform: String, incrementBuildTag: Bool, adoptOtherPlatformBuild: Bool, buildOffset: UInt = 0) {
+    showOutput = false
+    showCommands = false
+    verbose = false
+    semaphore = nil
+    error = nil
+
+    workspaceSettingsURL = URL(fileURLWithPath: ".rt.json")
+    workspaceSettings = WorkspaceSettings()
+
+    platform = testingPlatform
+    scheme = ""
+    apiKey = ""
+    apiIssuer = ""
+    package = URL(fileURLWithPath: FileManager.default.currentDirectoryPath).lastPathComponent
+    workspace = ""
+    self.buildOffset = buildOffset
+    self.incrementBuildTag = incrementBuildTag
+    self.adoptOtherPlatformBuild = adoptOtherPlatformBuild
+    archive = nil
   }
 
   func defaultKey(for key: String, platform: String) -> String {

--- a/Sources/ReleaseTools/OptionParser.swift
+++ b/Sources/ReleaseTools/OptionParser.swift
@@ -71,7 +71,7 @@ class OptionParser {
   var workspace: String = ""
   var buildOffset: UInt = 0
   var incrementBuildTag: Bool = true
-  var useExistingTag: Bool = false
+  var useExistingTag: Bool = true
   var archive: XcodeArchive!
 
   let rootURL = URL(fileURLWithPath: FileManager.default.currentDirectoryPath)

--- a/Sources/ReleaseTools/OptionParser.swift
+++ b/Sources/ReleaseTools/OptionParser.swift
@@ -180,33 +180,6 @@ class OptionParser {
       incrementBuildTag = true
     }
 
-    // validate that explicitBuild is not used with conflicting options
-    if explicitBuild != nil {
-      var conflictingOptions: [String] = []
-
-      if let buildOptions, buildOptions.useExistingTag {
-        conflictingOptions.append("--existing-tag")
-      } else if getSettings().useExistingTag == true {
-        conflictingOptions.append("useExistingTag setting")
-      }
-
-      if let buildOptions, buildOptions.incrementTag {
-        conflictingOptions.append("--increment-tag")
-      } else if getSettings().incrementTag == true {
-        conflictingOptions.append("incrementTag setting")
-      }
-
-      if let buildOptions, buildOptions.offset != nil {
-        conflictingOptions.append("--offset")
-      } else if getSettings().offset != nil {
-        conflictingOptions.append("offset setting")
-      }
-
-      if !conflictingOptions.isEmpty {
-        throw ValidationError("--explicit-build cannot be used with: \(conflictingOptions.joined(separator: ", "))")
-      }
-    }
-
     // if we've specified the scheme, we also need the workspace
     if requirements.contains(.workspace) || scheme != nil {
       if let workspace = options.workspace ?? defaultWorkspace {
@@ -264,6 +237,8 @@ class OptionParser {
       }
     }
 
+    // validate that explicitBuild is not used with conflicting options
+    try validateBuildOptionConflicts(buildOptions: buildOptions)
   }
 
   /// Lightweight initializer intended for tests where we only need build-number logic.
@@ -338,5 +313,34 @@ class OptionParser {
   func fail(_ error: Error) {
     self.error = error
     // semaphore?.signal()
+  }
+
+  /// Validates that explicitBuild is not used with conflicting options.
+  private func validateBuildOptionConflicts(buildOptions: BuildOptions?) throws {
+    if explicitBuild != nil {
+      var conflictingOptions: [String] = []
+
+      if let buildOptions, buildOptions.useExistingTag {
+        conflictingOptions.append("--existing-tag")
+      } else if getSettings().useExistingTag == true {
+        conflictingOptions.append("useExistingTag setting")
+      }
+
+      if let buildOptions, buildOptions.incrementTag {
+        conflictingOptions.append("--increment-tag")
+      } else if getSettings().incrementTag == true {
+        conflictingOptions.append("incrementTag setting")
+      }
+
+      if let buildOptions, buildOptions.offset != nil {
+        conflictingOptions.append("--offset")
+      } else if getSettings().offset != nil {
+        conflictingOptions.append("offset setting")
+      }
+
+      if !conflictingOptions.isEmpty {
+        throw ValidationError("--explicit-build cannot be used with: \(conflictingOptions.joined(separator: ", "))")
+      }
+    }
   }
 }

--- a/Sources/ReleaseTools/OptionParser.swift
+++ b/Sources/ReleaseTools/OptionParser.swift
@@ -150,7 +150,7 @@ class OptionParser {
       incrementBuildTag = setting
     }
 
-  // remember the useExistingTag setting if supplied in settings
+    // remember the useExistingTag setting if supplied in settings
     if let useExisting = getSettings().useExistingTag {
       useExistingTag = useExisting
     }
@@ -244,7 +244,7 @@ class OptionParser {
     workspace = ""
     self.buildOffset = buildOffset
     self.incrementBuildTag = incrementBuildTag
-  self.useExistingTag = adoptOtherPlatformBuild
+    self.useExistingTag = adoptOtherPlatformBuild
     archive = nil
   }
 

--- a/Sources/ReleaseTools/RootCommand.swift
+++ b/Sources/ReleaseTools/RootCommand.swift
@@ -50,9 +50,9 @@ struct RootCommand: AsyncParsableCommand {
   /// Main entrypoint.
   /// Note that this is overridden from the default implementation in `AsyncParsableCommand`,
   /// to allow us to flush the log after running the command.
-  public static func main() async {
+  public static func main(_ arguments: [String]?) async {
     do {
-      var command = try parseAsRoot(nil)
+      var command = try parseAsRoot(arguments)
       if var asyncCommand = command as? AsyncParsableCommand {
         try await asyncCommand.run()
       } else {

--- a/Sources/ReleaseTools/Runners/GitRunner.swift
+++ b/Sources/ReleaseTools/Runners/GitRunner.swift
@@ -7,12 +7,7 @@ import Foundation
 import Runner
 
 class GitRunner: Runner {
-
-  init() {
-    super.init(command: "git")
-  }
-
-  init(environment: [String: String]) {
+  init(environment: [String: String] = ProcessInfo.processInfo.environment) {
     super.init(command: "git", environment: environment)
   }
 }

--- a/Sources/ReleaseTools/Runners/GitRunner.swift
+++ b/Sources/ReleaseTools/Runners/GitRunner.swift
@@ -11,4 +11,8 @@ class GitRunner: Runner {
   init() {
     super.init(command: "git")
   }
+
+  init(environment: [String: String]) {
+    super.init(command: "git", environment: environment)
+  }
 }

--- a/Sources/ReleaseTools/SharedOptions.swift
+++ b/Sources/ReleaseTools/SharedOptions.swift
@@ -67,4 +67,5 @@ struct CommonOptions: ParsableArguments {
 struct BuildOptions: ParsableArguments {
   @Option(name: .customLong("offset"), help: "Integer offset to apply to the build number.") var offset: UInt?
   @Flag(help: "Calculate builds by looking for the highest existing build tag, and incrementing it. If this is false, we instead calculate the build number by counting the commits.") var incrementTag: Bool = false
+  @Flag(name: .customLong("adopt-other-platform-build"), help: "If a version tag for a different platform exists on the current commit, reuse its build number for this build.") var adoptOtherPlatformBuild: Bool = false
 }

--- a/Sources/ReleaseTools/SharedOptions.swift
+++ b/Sources/ReleaseTools/SharedOptions.swift
@@ -68,4 +68,27 @@ struct BuildOptions: ParsableArguments {
   @Option(name: .customLong("offset"), help: "Integer offset to apply to the build number.") var offset: UInt?
   @Flag(help: "Calculate builds by looking for the highest existing build tag, and incrementing it. If this is false, we instead calculate the build number by counting the commits.") var incrementTag: Bool = false
   @Flag(name: .customLong("existing-tag"), help: "If a version tag for a different platform exists on the current commit, reuse its build number for this build.") var useExistingTag: Bool = false
+  @Option(name: .customLong("explicit-build"), help: "Specify the exact build number to use. Cannot be used with --existing-tag, --increment-tag, or --offset.") var explicitBuild: String?
+  
+  mutating func validate() throws {
+    if let _ = explicitBuild {
+      var conflictingOptions: [String] = []
+      
+      if useExistingTag {
+        conflictingOptions.append("--existing-tag")
+      }
+      
+      if incrementTag {
+        conflictingOptions.append("--increment-tag")
+      }
+      
+      if offset != nil {
+        conflictingOptions.append("--offset")
+      }
+      
+      if !conflictingOptions.isEmpty {
+        throw ValidationError("--explicit-build cannot be used with: \(conflictingOptions.joined(separator: ", "))")
+      }
+    }
+  }
 }

--- a/Sources/ReleaseTools/SharedOptions.swift
+++ b/Sources/ReleaseTools/SharedOptions.swift
@@ -69,23 +69,23 @@ struct BuildOptions: ParsableArguments {
   @Flag(help: "Calculate builds by looking for the highest existing build tag, and incrementing it. If this is false, we instead calculate the build number by counting the commits.") var incrementTag: Bool = false
   @Flag(name: .customLong("existing-tag"), help: "If a version tag for a different platform exists on the current commit, reuse its build number for this build.") var useExistingTag: Bool = false
   @Option(name: .customLong("explicit-build"), help: "Specify the exact build number to use. Cannot be used with --existing-tag, --increment-tag, or --offset.") var explicitBuild: String?
-  
+
   mutating func validate() throws {
     if let _ = explicitBuild {
       var conflictingOptions: [String] = []
-      
+
       if useExistingTag {
         conflictingOptions.append("--existing-tag")
       }
-      
+
       if incrementTag {
         conflictingOptions.append("--increment-tag")
       }
-      
+
       if offset != nil {
         conflictingOptions.append("--offset")
       }
-      
+
       if !conflictingOptions.isEmpty {
         throw ValidationError("--explicit-build cannot be used with: \(conflictingOptions.joined(separator: ", "))")
       }

--- a/Sources/ReleaseTools/SharedOptions.swift
+++ b/Sources/ReleaseTools/SharedOptions.swift
@@ -67,5 +67,5 @@ struct CommonOptions: ParsableArguments {
 struct BuildOptions: ParsableArguments {
   @Option(name: .customLong("offset"), help: "Integer offset to apply to the build number.") var offset: UInt?
   @Flag(help: "Calculate builds by looking for the highest existing build tag, and incrementing it. If this is false, we instead calculate the build number by counting the commits.") var incrementTag: Bool = false
-  @Flag(name: .customLong("adopt-other-platform-build"), help: "If a version tag for a different platform exists on the current commit, reuse its build number for this build.") var adoptOtherPlatformBuild: Bool = false
+  @Flag(name: .customLong("existing-tag"), help: "If a version tag for a different platform exists on the current commit, reuse its build number for this build.") var useExistingTag: Bool = false
 }

--- a/Sources/ReleaseTools/WorkspaceSettings.swift
+++ b/Sources/ReleaseTools/WorkspaceSettings.swift
@@ -78,6 +78,7 @@ public class BasicSettings: Codable {
   public var offset: UInt?
   public var incrementTag: Bool?
   public var useExistingTag: Bool?
+  public var explicitBuild: String?
   public var apiKey: String?
   public var apiIssuer: String?
 
@@ -90,6 +91,7 @@ public class BasicSettings: Codable {
       offset = other.offset ?? offset
       incrementTag = other.incrementTag ?? incrementTag
       useExistingTag = other.useExistingTag ?? useExistingTag
+      explicitBuild = other.explicitBuild ?? explicitBuild
       apiKey = other.apiKey ?? apiKey
       apiIssuer = other.apiIssuer ?? apiIssuer
     }
@@ -109,6 +111,9 @@ public class BasicSettings: Codable {
         migrated = true
       case "existing-tag":
         useExistingTag = Bool(value)
+        migrated = true
+      case "explicit-build":
+        explicitBuild = value
         migrated = true
       case "api-key":
         apiKey = value

--- a/Sources/ReleaseTools/WorkspaceSettings.swift
+++ b/Sources/ReleaseTools/WorkspaceSettings.swift
@@ -77,6 +77,7 @@ public class BasicSettings: Codable {
   public var keychain: String?
   public var offset: UInt?
   public var incrementTag: Bool?
+  public var adoptOtherPlatformBuild: Bool?
   public var apiKey: String?
   public var apiIssuer: String?
 
@@ -88,6 +89,7 @@ public class BasicSettings: Codable {
       keychain = other.keychain ?? keychain
       offset = other.offset ?? offset
       incrementTag = other.incrementTag ?? incrementTag
+      adoptOtherPlatformBuild = other.adoptOtherPlatformBuild ?? adoptOtherPlatformBuild
       apiKey = other.apiKey ?? apiKey
       apiIssuer = other.apiIssuer ?? apiIssuer
     }
@@ -104,6 +106,9 @@ public class BasicSettings: Codable {
         migrated = true
       case "increment-tag":
         incrementTag = Bool(value)
+        migrated = true
+      case "adopt-other-platform-build":
+        adoptOtherPlatformBuild = Bool(value)
         migrated = true
       case "api-key":
         apiKey = value

--- a/Sources/ReleaseTools/WorkspaceSettings.swift
+++ b/Sources/ReleaseTools/WorkspaceSettings.swift
@@ -77,7 +77,7 @@ public class BasicSettings: Codable {
   public var keychain: String?
   public var offset: UInt?
   public var incrementTag: Bool?
-  public var adoptOtherPlatformBuild: Bool?
+  public var useExistingTag: Bool?
   public var apiKey: String?
   public var apiIssuer: String?
 
@@ -89,7 +89,7 @@ public class BasicSettings: Codable {
       keychain = other.keychain ?? keychain
       offset = other.offset ?? offset
       incrementTag = other.incrementTag ?? incrementTag
-      adoptOtherPlatformBuild = other.adoptOtherPlatformBuild ?? adoptOtherPlatformBuild
+      useExistingTag = other.useExistingTag ?? useExistingTag
       apiKey = other.apiKey ?? apiKey
       apiIssuer = other.apiIssuer ?? apiIssuer
     }
@@ -107,8 +107,8 @@ public class BasicSettings: Codable {
       case "increment-tag":
         incrementTag = Bool(value)
         migrated = true
-      case "adopt-other-platform-build":
-        adoptOtherPlatformBuild = Bool(value)
+      case "existing-tag":
+        useExistingTag = Bool(value)
         migrated = true
       case "api-key":
         apiKey = value

--- a/Tests/ReleaseToolsTests/BuildNumberTests.swift
+++ b/Tests/ReleaseToolsTests/BuildNumberTests.swift
@@ -76,8 +76,6 @@ struct BuildNumberTests {
     return git
   }
 
-
-
   // MARK: - Tests
 
   @Test func adoptsBuildFromOtherPlatformTagAtHEAD() async throws {
@@ -93,7 +91,7 @@ struct BuildNumberTests {
     #expect(pts.stdout.contains("v1.2.3-42-iOS"))
 
     let git = gitRunner(for: repo)
-  let parsed = OptionParser(testingPlatform: "macOS", incrementBuildTag: false, adoptOtherPlatformBuild: true)
+    let parsed = OptionParser(testingPlatform: "macOS", incrementBuildTag: false, adoptOtherPlatformBuild: true)
     let (build, _) = try await parsed.nextBuildNumberAndCommit(in: repo, using: git)
     #expect(build == "42")
   }
@@ -115,7 +113,7 @@ struct BuildNumberTests {
 
     let git = gitRunner(for: repo)
     // useExistingTag now implies incrementBuildTag, so incrementTag parameter is ignored
-  let parsed = OptionParser(testingPlatform: "macOS", incrementBuildTag: false, adoptOtherPlatformBuild: true)
+    let parsed = OptionParser(testingPlatform: "macOS", incrementBuildTag: false, adoptOtherPlatformBuild: true)
     let (build, _) = try await parsed.nextBuildNumberAndCommit(in: repo, using: git)
     #expect(build == "99")
   }
@@ -134,7 +132,7 @@ struct BuildNumberTests {
     // When no adoption happens at HEAD, fall back to incrementTag.
     // The highest macOS build is 11, so we should get 12.
     let git = gitRunner(for: repo)
-  let parsed = OptionParser(testingPlatform: "macOS", incrementBuildTag: true, adoptOtherPlatformBuild: true)
+    let parsed = OptionParser(testingPlatform: "macOS", incrementBuildTag: true, adoptOtherPlatformBuild: true)
     let (build, _) = try await parsed.nextBuildNumberAndCommit(in: repo, using: git)
     #expect(build == "12")
   }
@@ -146,7 +144,7 @@ struct BuildNumberTests {
 
     let git = gitRunner(for: repo)
     // useExistingTag now implies incrementBuildTag, so it falls back to incrementTag (not commit count)
-  let parsed = OptionParser(testingPlatform: "macOS", incrementBuildTag: false, adoptOtherPlatformBuild: true)
+    let parsed = OptionParser(testingPlatform: "macOS", incrementBuildTag: false, adoptOtherPlatformBuild: true)
     let (build, _) = try await parsed.nextBuildNumberAndCommit(in: repo, using: git)
     // no existing tags for macOS, so incrementTag returns 1
     #expect(build == "1")
@@ -159,7 +157,7 @@ struct BuildNumberTests {
 
     let git = gitRunner(for: repo)
     // with adopt: false and incrementTag: false, should use commit count
-  let parsed = OptionParser(testingPlatform: "macOS", incrementBuildTag: false, adoptOtherPlatformBuild: false)
+    let parsed = OptionParser(testingPlatform: "macOS", incrementBuildTag: false, adoptOtherPlatformBuild: false)
     let (build, _) = try await parsed.nextBuildNumberAndCommit(in: repo, using: git)
     // we made two commits total
     #expect(build == "2")
@@ -167,14 +165,14 @@ struct BuildNumberTests {
 
   @Test func useExistingTagImpliesIncrementTag() async throws {
     // This test verifies that useExistingTag automatically enables incrementBuildTag
-  let parsed = OptionParser(testingPlatform: "macOS", incrementBuildTag: false, adoptOtherPlatformBuild: true)
+    let parsed = OptionParser(testingPlatform: "macOS", incrementBuildTag: false, adoptOtherPlatformBuild: true)
 
     // Even though we passed incrementTag: false, useExistingTag should have overridden it
     #expect(parsed.useExistingTag, "useExistingTag should be true")
     #expect(parsed.incrementBuildTag, "incrementBuildTag should be true due to useExistingTag implication")
 
     // Test the opposite case for comparison (explicitly disable useExistingTag)
-  let parsedNoAdopt = OptionParser(testingPlatform: "macOS", incrementBuildTag: false, adoptOtherPlatformBuild: false)
+    let parsedNoAdopt = OptionParser(testingPlatform: "macOS", incrementBuildTag: false, adoptOtherPlatformBuild: false)
     #expect(!parsedNoAdopt.useExistingTag, "useExistingTag should be false when explicitly disabled")
     #expect(!parsedNoAdopt.incrementBuildTag, "incrementBuildTag should be false")
   }
@@ -193,7 +191,7 @@ struct BuildNumberTests {
     #expect(pts.stdout.contains("v1.2.3-42-iOS"), Comment(rawValue: "Expected v1.2.3-42-iOS in tags at HEAD: \(pts.stdout)"))
 
     let git = gitRunner(for: repo)
-  let parsed = OptionParser(testingPlatform: "macOS", incrementBuildTag: true, adoptOtherPlatformBuild: true)
+    let parsed = OptionParser(testingPlatform: "macOS", incrementBuildTag: true, adoptOtherPlatformBuild: true)
     let (build, _) = try await parsed.nextBuildNumberAndCommit(in: repo, using: git)
     // should adopt 42 from iOS even though macOS tag also exists at HEAD
     #expect(build == "42")
@@ -205,7 +203,7 @@ struct BuildNumberTests {
     try await tag(at: repo, name: "v3.4.5-42-iOS")
 
     let git = gitRunner(for: repo)
-  let parsed = OptionParser(testingPlatform: "macOS", incrementBuildTag: true, adoptOtherPlatformBuild: true, buildOffset: 100)
+    let parsed = OptionParser(testingPlatform: "macOS", incrementBuildTag: true, adoptOtherPlatformBuild: true, buildOffset: 100)
     let (build, _) = try await parsed.nextBuildNumberAndCommit(in: repo, using: git)
     // offset is ignored when adopting; should not be 142
     #expect(build == "42")
@@ -232,7 +230,7 @@ struct BuildNumberTests {
     // When adoption is disabled and incrementTag is enabled, we should
     // pick max macOS build (11) globally and add 1 => 12.
     let git = gitRunner(for: repo)
-  let parsed = OptionParser(testingPlatform: "macOS", incrementBuildTag: true, adoptOtherPlatformBuild: false)
+    let parsed = OptionParser(testingPlatform: "macOS", incrementBuildTag: true, adoptOtherPlatformBuild: false)
     let (build, _) = try await parsed.nextBuildNumberAndCommit(in: repo, using: git)
     #expect(build == "12")
   }
@@ -242,7 +240,7 @@ struct BuildNumberTests {
     try await initGitRepo(at: repo)
 
     let git = gitRunner(for: repo)
-  let parsed = OptionParser(testingPlatform: "macOS", incrementBuildTag: false, adoptOtherPlatformBuild: false, explicitBuild: "42")
+    let parsed = OptionParser(testingPlatform: "macOS", incrementBuildTag: false, adoptOtherPlatformBuild: false, explicitBuild: "42")
     let (build, _) = try await parsed.nextBuildNumberAndCommit(in: repo, using: git)
     #expect(build == "42")
   }
@@ -254,7 +252,7 @@ struct BuildNumberTests {
     try await tag(at: repo, name: "v1.0-200-iOS")
 
     let git = gitRunner(for: repo)
-  let parsed = OptionParser(testingPlatform: "macOS", incrementBuildTag: false, adoptOtherPlatformBuild: false, explicitBuild: "5")
+    let parsed = OptionParser(testingPlatform: "macOS", incrementBuildTag: false, adoptOtherPlatformBuild: false, explicitBuild: "5")
     let (build, _) = try await parsed.nextBuildNumberAndCommit(in: repo, using: git)
     #expect(build == "5")
   }
@@ -264,7 +262,7 @@ struct BuildNumberTests {
     try await initGitRepo(at: repo)
 
     let git = gitRunner(for: repo)
-  let parsed = OptionParser(testingPlatform: "macOS", incrementBuildTag: false, adoptOtherPlatformBuild: false, explicitBuild: "not-a-number")
+    let parsed = OptionParser(testingPlatform: "macOS", incrementBuildTag: false, adoptOtherPlatformBuild: false, explicitBuild: "not-a-number")
 
     do {
       let _ = try await parsed.nextBuildNumberAndCommit(in: repo, using: git)

--- a/Tests/ReleaseToolsTests/BuildNumberTests.swift
+++ b/Tests/ReleaseToolsTests/BuildNumberTests.swift
@@ -184,9 +184,9 @@ final class BuildNumberTests: XCTestCase {
     XCTAssertTrue(parsed.useExistingTag, "useExistingTag should be true")
     XCTAssertTrue(parsed.incrementBuildTag, "incrementBuildTag should be true due to useExistingTag implication")
 
-    // Test the opposite case for comparison
+    // Test the opposite case for comparison (explicitly disable useExistingTag)
     let parsedNoAdopt = try parser(platform: "macOS", adopt: false, incrementTag: false)
-    XCTAssertFalse(parsedNoAdopt.useExistingTag, "useExistingTag should be false")
+    XCTAssertFalse(parsedNoAdopt.useExistingTag, "useExistingTag should be false when explicitly disabled")
     XCTAssertFalse(parsedNoAdopt.incrementBuildTag, "incrementBuildTag should be false")
   }
 

--- a/Tests/ReleaseToolsTests/BuildNumberTests.swift
+++ b/Tests/ReleaseToolsTests/BuildNumberTests.swift
@@ -1,0 +1,164 @@
+// -=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
+//  Created by Tests on 24/09/25.
+//  All code (c) 2025 - present day, Elegant Chaos Limited.
+// -=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
+
+import Foundation
+import XCTest
+import ArgumentParser
+@testable import ReleaseTools
+
+final class BuildNumberTests: XCTestCase {
+
+  // MARK: - Helpers
+
+  func makeTempDir() throws -> URL {
+    let url = URL(fileURLWithPath: NSTemporaryDirectory())
+      .appendingPathComponent("ReleaseToolsTests-\(UUID().uuidString)")
+    try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+    return url
+  }
+
+  @discardableResult
+  func sh(_ args: [String], cwd: URL) throws -> (stdout: String, stderr: String, code: Int32) {
+    let task = Process()
+    task.currentDirectoryURL = cwd
+    task.executableURL = URL(fileURLWithPath: "/usr/bin/env")
+    task.arguments = args
+
+    let out = Pipe(); task.standardOutput = out
+    let err = Pipe(); task.standardError = err
+    try task.run()
+    task.waitUntilExit()
+
+    let dataOut = out.fileHandleForReading.readDataToEndOfFile()
+    let dataErr = err.fileHandleForReading.readDataToEndOfFile()
+    return (
+      String(decoding: dataOut, as: UTF8.self),
+      String(decoding: dataErr, as: UTF8.self),
+      task.terminationStatus
+    )
+  }
+
+  func initGitRepo(at url: URL) throws {
+    let r0 = try sh(["git", "init"], cwd: url); XCTAssertEqual(r0.code, 0, r0.stderr)
+  let r1 = try sh(["git", "config", "user.name", "Test User"], cwd: url); XCTAssertEqual(r1.code, 0, r1.stderr)
+  let r2 = try sh(["git", "config", "user.email", "test@example.com"], cwd: url); XCTAssertEqual(r2.code, 0, r2.stderr)
+  let r1b = try sh(["git", "config", "commit.gpgsign", "false"], cwd: url); XCTAssertEqual(r1b.code, 0, r1b.stderr)
+  let r1c = try sh(["git", "config", "tag.gpgSign", "false"], cwd: url); XCTAssertEqual(r1c.code, 0, r1c.stderr)
+    try "initial".write(to: url.appendingPathComponent("file.txt"), atomically: true, encoding: .utf8)
+    let r3 = try sh(["git", "add", "."], cwd: url); XCTAssertEqual(r3.code, 0, r3.stderr)
+    let r4 = try sh(["git", "commit", "-m", "initial"], cwd: url); XCTAssertEqual(r4.code, 0, r4.stderr)
+    let r5 = try sh(["git","rev-parse","--verify","HEAD"], cwd: url); XCTAssertEqual(r5.code, 0, r5.stderr)
+
+    // Create a separate bare remote so that `git fetch --tags` always succeeds
+    let remote = try makeTempDir()
+    let b0 = try sh(["git", "init", "--bare"], cwd: remote); XCTAssertEqual(b0.code, 0, b0.stderr)
+    let b1 = try sh(["git", "remote", "add", "origin", remote.path], cwd: url); XCTAssertEqual(b1.code, 0, b1.stderr)
+    let b2 = try sh(["git", "push", "-u", "origin", "HEAD"], cwd: url); XCTAssertEqual(b2.code, 0, b2.stderr)
+  }
+
+  func commit(at url: URL, message: String = "update") throws {
+    let p = url.appendingPathComponent("file.txt")
+    try (UUID().uuidString).appendLine(to: p)
+    _ = try sh(["git", "add", "."], cwd: url)
+    _ = try sh(["git", "commit", "-m", message], cwd: url)
+  }
+
+  func tag(at url: URL, name: String) throws {
+    _ = try sh(["git", "tag", name], cwd: url)
+  }
+
+  func gitRunner(for repo: URL) -> GitRunner {
+    var env = ProcessInfo.processInfo.environment
+    env.removeValue(forKey: "GIT_DIR")
+    env.removeValue(forKey: "GIT_WORK_TREE")
+    env.removeValue(forKey: "GIT_INDEX_FILE")
+    let git = GitRunner(environment: env)
+    git.cwd = repo
+    return git
+  }
+
+  func parser(platform: String, adopt: Bool, incrementTag: Bool) throws -> OptionParser {
+    return OptionParser(testingPlatform: platform, incrementBuildTag: incrementTag, adoptOtherPlatformBuild: adopt)
+  }
+
+  // MARK: - Tests
+
+  func testAdoptsBuildFromOtherPlatformTagAtHEAD() async throws {
+    let repo = try makeTempDir()
+    try initGitRepo(at: repo)
+    try tag(at: repo, name: "v1.2.3-42-iOS")
+
+    // Sanity: HEAD should resolve and tag should point at it
+    let head = try sh(["git","rev-parse","--verify","HEAD"], cwd: repo)
+    XCTAssertEqual(head.code, 0, head.stderr)
+    let pts = try sh(["git","tag","--points-at","HEAD"], cwd: repo)
+    XCTAssertTrue(pts.stdout.contains("v1.2.3-42-iOS"))
+
+    let git = gitRunner(for: repo)
+    let parsed = try parser(platform: "macOS", adopt: true, incrementTag: false)
+  let (build, _) = try await parsed.nextBuildNumberAndCommit(in: repo, using: git)
+    XCTAssertEqual(build, "42")
+  }
+
+  func testAdoptChoosesHighestBuildAcrossOtherPlatformsAtHEAD() async throws {
+    let repo = try makeTempDir()
+    try initGitRepo(at: repo)
+    try tag(at: repo, name: "v1.2.3-10-iOS")
+    try tag(at: repo, name: "v2.0-99-tvOS")
+    try tag(at: repo, name: "v2.0-77-macCatalyst")
+
+    // Sanity
+    let head = try sh(["git","rev-parse","--verify","HEAD"], cwd: repo)
+    XCTAssertEqual(head.code, 0, head.stderr)
+    let pts = try sh(["git","tag","--points-at","HEAD"], cwd: repo)
+    XCTAssertTrue(pts.stdout.contains("v2.0-99-tvOS"))
+
+    let git = gitRunner(for: repo)
+    let parsed = try parser(platform: "macOS", adopt: true, incrementTag: false)
+  let (build, _) = try await parsed.nextBuildNumberAndCommit(in: repo, using: git)
+    XCTAssertEqual(build, "99")
+  }
+
+  func testNoAdoptionFallsBackToIncrementTag() async throws {
+    let repo = try makeTempDir()
+    try initGitRepo(at: repo)
+    // add some unrelated platform tags at other commits
+    try tag(at: repo, name: "v1.0-5-macOS")
+    try commit(at: repo, message: "work")
+    try tag(at: repo, name: "v1.1-11-macOS")
+
+    let git = gitRunner(for: repo)
+    let parsed = try parser(platform: "macOS", adopt: true, incrementTag: true)
+  let (build, _) = try await parsed.nextBuildNumberAndCommit(in: repo, using: git)
+    // highest existing macOS tag is 11, so next should be 12
+    XCTAssertEqual(build, "12")
+  }
+
+  func testNoAdoptionFallsBackToCommitCount() async throws {
+    let repo = try makeTempDir()
+    try initGitRepo(at: repo)
+    try commit(at: repo, message: "second")
+
+    let git = gitRunner(for: repo)
+    let parsed = try parser(platform: "macOS", adopt: true, incrementTag: false)
+  let (build, _) = try await parsed.nextBuildNumberAndCommit(in: repo, using: git)
+    // we made two commits total
+    XCTAssertEqual(build, "2")
+  }
+}
+
+private extension String {
+  func appendLine(to url: URL) throws {
+    let data = (self + "\n").data(using: .utf8)!
+    if FileManager.default.fileExists(atPath: url.path) {
+      let handle = try FileHandle(forWritingTo: url)
+      try handle.seekToEnd()
+      try handle.write(contentsOf: data)
+      try handle.close()
+    } else {
+      try data.write(to: url)
+    }
+  }
+}

--- a/Tests/ReleaseToolsTests/BuildNumberTests.swift
+++ b/Tests/ReleaseToolsTests/BuildNumberTests.swift
@@ -187,8 +187,8 @@ struct BuildNumberTests {
     // sanity
     let gitSanity = gitRunner(for: repo)
     let pts = await runGit(gitSanity, ["tag", "--points-at", "HEAD"])
-    #expect(pts.stdout.contains("v1.2.3-40-macOS"), Comment(rawValue: "Expected v1.2.3-40-macOS in tags at HEAD: \(pts.stdout)"))
-    #expect(pts.stdout.contains("v1.2.3-42-iOS"), Comment(rawValue: "Expected v1.2.3-42-iOS in tags at HEAD: \(pts.stdout)"))
+    #expect(pts.stdout.contains("v1.2.3-40-macOS"), "Expected v1.2.3-40-macOS in tags at HEAD: \(pts.stdout)")
+    #expect(pts.stdout.contains("v1.2.3-42-iOS"), "Expected v1.2.3-42-iOS in tags at HEAD: \(pts.stdout)")
 
     let git = gitRunner(for: repo)
     let parsed = OptionParser(testingPlatform: "macOS", incrementBuildTag: true, adoptOtherPlatformBuild: true)
@@ -224,8 +224,8 @@ struct BuildNumberTests {
     // Sanity: tags at HEAD should include these
     let sanity = gitRunner(for: repo)
     let pts = await runGit(sanity, ["tag", "--points-at", "HEAD"])
-    #expect(pts.stdout.contains("v2.0-99-iOS"), Comment(rawValue: "Expected v2.0-99-iOS in tags at HEAD: \(pts.stdout)"))
-    #expect(pts.stdout.contains("v1.0-2-macOS"), Comment(rawValue: "Expected v1.0-2-macOS in tags at HEAD: \(pts.stdout)"))
+    #expect(pts.stdout.contains("v2.0-99-iOS"), "Expected v2.0-99-iOS in tags at HEAD: \(pts.stdout)")
+    #expect(pts.stdout.contains("v1.0-2-macOS"), "Expected v1.0-2-macOS in tags at HEAD: \(pts.stdout)")
 
     // When adoption is disabled and incrementTag is enabled, we should
     // pick max macOS build (11) globally and add 1 => 12.
@@ -266,9 +266,16 @@ struct BuildNumberTests {
 
     do {
       let _ = try await parsed.nextBuildNumberAndCommit(in: repo, using: git)
-      #expect(Bool(false), Comment(rawValue: "Should have thrown ValidationError"))
+      #expect(Bool(false), "Should have thrown UpdateBuildError.invalidExplicitBuild")
+    } catch let error as UpdateBuildError {
+      switch error {
+        case .invalidExplicitBuild:
+          #expect(true)
+        default:
+          #expect(Bool(false), "Should throw UpdateBuildError.invalidExplicitBuild for invalid number, got: \(error)")
+      }
     } catch {
-      #expect(error is ValidationError, Comment(rawValue: "Should throw ValidationError for invalid number"))
+      #expect(Bool(false), "Should throw UpdateBuildError.invalidExplicitBuild for invalid number, got: \(error)")
     }
   }
 }

--- a/Tests/ReleaseToolsTests/BuildNumberTests.swift
+++ b/Tests/ReleaseToolsTests/BuildNumberTests.swift
@@ -70,13 +70,16 @@ final class BuildNumberTests: XCTestCase {
     let git = gitRunner(for: url)
     let p = url.appendingPathComponent("file.txt")
     try (UUID().uuidString).appendLine(to: p)
-    _ = await runGit(git, ["add", "."])
-    _ = await runGit(git, ["commit", "-m", message])
+    let add = await runGit(git, ["add", "."]) 
+    XCTAssertEqual(add.code, 0, add.stderr)
+    let commit = await runGit(git, ["commit", "-m", message])
+    XCTAssertEqual(commit.code, 0, commit.stderr)
   }
 
   func tag(at url: URL, name: String) async throws {
     let git = gitRunner(for: url)
-    _ = await runGit(git, ["tag", name])
+    let t = await runGit(git, ["tag", name])
+    XCTAssertEqual(t.code, 0, t.stderr)
   }
 
   func gitRunner(for repo: URL) -> GitRunner {


### PR DESCRIPTION
Adds an option which checks for an existing version tag at HEAD for a different platform.

If we find one, we use the build number from it.

This makes it easier to keep build numbers in sync when releasing versions from different platforms.