### PR TITLE
Validate Xcode schemes on supported platforms

### DIFF
--- a/Sources/ReleaseTools/Commands/ValidateCommand.swift
+++ b/Sources/ReleaseTools/Commands/ValidateCommand.swift
@@ -53,7 +53,7 @@ func usage() {
       --workspace <path>           Explicit workspace path (absolute or repo-relative)
       --project <path>             Explicit project path (absolute or repo-relative)
       --schemes <csv>              Xcode schemes for broad validation (default: repo name)
-      --destinations <csv>         Xcode build destinations (default: generic/platform=iOS,generic/platform=macOS)
+      --destinations <csv>         Xcode build destinations (default: platforms supported by the scheme)
       --run-xcode-tests            Also run xcodebuild test for test destinations
       --test-destinations <csv>    Xcode test destinations (default: platform=macOS)
       --package-dirs <csv>         Package directories for SwiftPM checks (absolute or repo-relative)
@@ -622,7 +622,6 @@ func parseArgs(_ args: [String]) throws -> Config {
 
   let repoPath = FileManager.default.currentDirectoryPath
   if schemes.isEmpty { schemes = [repoName(repoPath)] }
-  if destinations.isEmpty { destinations = ["generic/platform=iOS", "generic/platform=macOS"] }
   if testDestinations.isEmpty { testDestinations = ["platform=macOS"] }
 
   return Config(
@@ -700,7 +699,16 @@ func runXcodeBroadValidation(
   let actions = config.clean ? ["clean", "build"] : ["build"]
 
   for scheme in config.schemes {
-    for destination in config.destinations {
+    let destinations = try buildDestinations(
+      config: config,
+      repoPath: repoPath,
+      tools: tools,
+      workspace: workspace,
+      project: nil,
+      scheme: scheme
+    )
+
+    for destination in destinations {
       let log = "\(tools.verifyRoot)/comprehensive_\(sanitize(scheme))_\(sanitize(destination))_build.log"
       var args = [
         "xcodebuild",
@@ -757,6 +765,78 @@ func runXcodeBroadValidation(
         )
       }
     }
+  }
+}
+
+func xcodeShowBuildSettingsArguments(workspace: String?, project: String?, scheme: String) -> [String] {
+  var args = ["xcodebuild"]
+  if let workspace {
+    args += ["-workspace", workspace]
+  } else if let project {
+    args += ["-project", project]
+  }
+  args += ["-scheme", scheme, "-showBuildSettings", "-json"]
+  return args
+}
+
+func buildDestinations(
+  config: Config,
+  repoPath: String,
+  tools: ToolingPaths,
+  workspace: String?,
+  project: String?,
+  scheme: String
+) throws -> [String] {
+  if !config.destinations.isEmpty {
+    return config.destinations
+  }
+
+  let args = xcodeShowBuildSettingsArguments(workspace: workspace, project: project, scheme: scheme)
+  let result = try capture("/usr/bin/env", args, cwd: repoPath, environment: tools.env)
+  guard result.status == 0 else {
+    throw CLIError(message: "Failed to read supported platforms for scheme '\(scheme)':\n\(result.stderr)")
+  }
+
+  let destinations = try buildDestinations(fromBuildSettingsJSON: result.stdout)
+  guard !destinations.isEmpty else {
+    throw CLIError(message: "No supported build destinations found for scheme '\(scheme)'. Provide --destinations to override platform detection.")
+  }
+  return destinations
+}
+
+func buildDestinations(fromBuildSettingsJSON output: String) throws -> [String] {
+  guard let data = output.data(using: .utf8) else { return [] }
+  let entries = try JSONDecoder().decode([XcodeBuildSettingsEntry].self, from: data)
+  let sdkPlatforms = entries.flatMap { entry in
+    entry.buildSettings["SUPPORTED_PLATFORMS"]?
+      .split { $0 == " " || $0 == "," || $0 == "\n" || $0 == "\t" }
+      .map(String.init) ?? []
+  }
+
+  var destinations: [String] = []
+  for sdkPlatform in sdkPlatforms {
+    guard let destination = buildDestination(forSupportedPlatform: sdkPlatform), !destinations.contains(destination) else {
+      continue
+    }
+    destinations.append(destination)
+  }
+  return destinations
+}
+
+func buildDestination(forSupportedPlatform sdkPlatform: String) -> String? {
+  switch sdkPlatform {
+    case "macosx":
+      return "generic/platform=macOS"
+    case "iphoneos", "iphonesimulator":
+      return "generic/platform=iOS"
+    case "appletvos", "appletvsimulator":
+      return "generic/platform=tvOS"
+    case "watchos", "watchsimulator":
+      return "generic/platform=watchOS"
+    case "xros", "xrsimulator":
+      return "generic/platform=visionOS"
+    default:
+      return nil
   }
 }
 
@@ -1074,7 +1154,16 @@ func runValidationFlow(_ arguments: [String]) throws {
 
     if let project {
       for scheme in config.schemes {
-        for destination in config.destinations {
+        let destinations = try buildDestinations(
+          config: config,
+          repoPath: repoPath,
+          tools: tools,
+          workspace: nil,
+          project: project,
+          scheme: scheme
+        )
+
+        for destination in destinations {
           var args = [
             "xcodebuild",
             "-project", project,

--- a/Sources/ReleaseTools/Commands/ValidateCommand.swift
+++ b/Sources/ReleaseTools/Commands/ValidateCommand.swift
@@ -768,14 +768,19 @@ func runXcodeBroadValidation(
   }
 }
 
-func xcodeShowBuildSettingsArguments(workspace: String?, project: String?, scheme: String) -> [String] {
+func xcodeShowBuildSettingsArguments(
+  workspace: String?,
+  project: String?,
+  scheme: String,
+  derivedDataPath: String
+) -> [String] {
   var args = ["xcodebuild"]
   if let workspace {
     args += ["-workspace", workspace]
   } else if let project {
     args += ["-project", project]
   }
-  args += ["-scheme", scheme, "-showBuildSettings", "-json"]
+  args += ["-scheme", scheme, "-derivedDataPath", derivedDataPath, "-showBuildSettings", "-json"]
   return args
 }
 
@@ -791,7 +796,12 @@ func buildDestinations(
     return config.destinations
   }
 
-  let args = xcodeShowBuildSettingsArguments(workspace: workspace, project: project, scheme: scheme)
+  let args = xcodeShowBuildSettingsArguments(
+    workspace: workspace,
+    project: project,
+    scheme: scheme,
+    derivedDataPath: tools.derivedDataPath
+  )
   let result = try capture("/usr/bin/env", args, cwd: repoPath, environment: tools.env)
   guard result.status == 0 else {
     throw CLIError(message: "Failed to read supported platforms for scheme '\(scheme)':\n\(result.stderr)")

--- a/Sources/ReleaseTools/Commands/ValidateCommandModels.swift
+++ b/Sources/ReleaseTools/Commands/ValidateCommandModels.swift
@@ -28,6 +28,11 @@ struct PackageDescription: Decodable {
   let targets: [TargetInfo]
 }
 
+/// Minimal build settings metadata decoded from `xcodebuild -showBuildSettings -json`.
+struct XcodeBuildSettingsEntry: Decodable {
+  let buildSettings: [String: String]
+}
+
 /// Derived filesystem and environment paths for a validation run.
 struct ToolingPaths {
   let verifyRoot: String

--- a/Tests/ReleaseToolsTests/ValidateCommandDiscoveryTests.swift
+++ b/Tests/ReleaseToolsTests/ValidateCommandDiscoveryTests.swift
@@ -77,6 +77,16 @@ struct ValidateCommandDiscoveryTests {
     #expect(config.outputMode == expected)
   }
 
+  @Test func destinationsDefaultToPlatformDiscovery() throws {
+    let config = try parseArgs([])
+    #expect(config.destinations.isEmpty)
+  }
+
+  @Test func explicitDestinationsArePreserved() throws {
+    let config = try parseArgs(["--destinations", "generic/platform=macOS,generic/platform=watchOS"])
+    #expect(config.destinations == ["generic/platform=macOS", "generic/platform=watchOS"])
+  }
+
   @Test func invalidOutputModeThrows() {
     #expect(throws: CLIError.self) {
       _ = try parseArgs(["--output", "loud"])
@@ -121,6 +131,44 @@ struct ValidateCommandDiscoveryTests {
   ])
   func filteredValidationLineBehavior(line: String, expected: String?) {
     #expect(filteredValidationLine(line) == expected)
+  }
+
+  @Test func buildDestinationMapsSupportedSDKPlatforms() {
+    #expect(buildDestination(forSupportedPlatform: "macosx") == "generic/platform=macOS")
+    #expect(buildDestination(forSupportedPlatform: "iphoneos") == "generic/platform=iOS")
+    #expect(buildDestination(forSupportedPlatform: "iphonesimulator") == "generic/platform=iOS")
+    #expect(buildDestination(forSupportedPlatform: "appletvos") == "generic/platform=tvOS")
+    #expect(buildDestination(forSupportedPlatform: "appletvsimulator") == "generic/platform=tvOS")
+    #expect(buildDestination(forSupportedPlatform: "watchos") == "generic/platform=watchOS")
+    #expect(buildDestination(forSupportedPlatform: "watchsimulator") == "generic/platform=watchOS")
+    #expect(buildDestination(forSupportedPlatform: "xros") == "generic/platform=visionOS")
+    #expect(buildDestination(forSupportedPlatform: "xrsimulator") == "generic/platform=visionOS")
+    #expect(buildDestination(forSupportedPlatform: "driverkit") == nil)
+  }
+
+  @Test func buildDestinationsDecodeSupportedPlatformsFromBuildSettings() throws {
+    let output = """
+      [
+        {
+          "buildSettings": {
+            "SUPPORTED_PLATFORMS": "iphoneos iphonesimulator"
+          }
+        },
+        {
+          "buildSettings": {
+            "SUPPORTED_PLATFORMS": "macosx watchos watchsimulator"
+          }
+        }
+      ]
+      """
+
+    #expect(
+      try buildDestinations(fromBuildSettingsJSON: output) == [
+        "generic/platform=iOS",
+        "generic/platform=macOS",
+        "generic/platform=watchOS",
+      ]
+    )
   }
 
   @Test func extractedFailureDiagnosticsPreferErrorBlock() {

--- a/Tests/ReleaseToolsTests/ValidateCommandDiscoveryTests.swift
+++ b/Tests/ReleaseToolsTests/ValidateCommandDiscoveryTests.swift
@@ -87,6 +87,24 @@ struct ValidateCommandDiscoveryTests {
     #expect(config.destinations == ["generic/platform=macOS", "generic/platform=watchOS"])
   }
 
+  @Test func buildSettingsDiscoveryUsesRepoLocalDerivedData() {
+    #expect(
+      xcodeShowBuildSettingsArguments(
+        workspace: "App.xcworkspace",
+        project: nil,
+        scheme: "App",
+        derivedDataPath: ".build/rt-validate/DerivedData"
+      ) == [
+        "xcodebuild",
+        "-workspace", "App.xcworkspace",
+        "-scheme", "App",
+        "-derivedDataPath", ".build/rt-validate/DerivedData",
+        "-showBuildSettings",
+        "-json",
+      ]
+    )
+  }
+
   @Test func invalidOutputModeThrows() {
     #expect(throws: CLIError.self) {
       _ = try parseArgs(["--output", "loud"])


### PR DESCRIPTION
## Summary

- Detect Xcode build destinations from each scheme's `SUPPORTED_PLATFORMS`.
- Preserve explicit `--destinations` overrides.
- Add regression coverage for default platform discovery and supported SDK mapping.

## Validation

- `swift test --filter ValidateCommandDiscoveryTests`
- `rt validate --target ReleaseTools`
- `rt validate`
